### PR TITLE
Add jdk8 method to GFramePeer

### DIFF
--- a/src/ghostawt/GFramePeer.java
+++ b/src/ghostawt/GFramePeer.java
@@ -43,4 +43,8 @@ public class GFramePeer extends GWindowPeer implements FramePeer {
     public Rectangle getBoundsPrivate() {
         return null;
     }
+
+    @Override
+    public void emulateActivation(boolean activate) {
+    }
 }


### PR DESCRIPTION
The method emulateActivation was added to java.awt.FramePeer in
jdk8. This change will allow GhostAWT to compile against jdk8.